### PR TITLE
timestamps rework and can fix

### DIFF
--- a/BMSModuleManager.cpp
+++ b/BMSModuleManager.cpp
@@ -193,8 +193,14 @@ uint16_t BMSModuleManager::getAllVoltTemp() {
     numOfBoards = y;
     if (modules[y].getAddress() > 0 && modules[y].updateInstanceWithModuleValues()) {
       tempPackVolt += modules[y].getModuleVoltage();
-      if (modules[y].getLowTemp() < histLowestPackTemp) histLowestPackTemp = modules[y].getLowTemp();
-      if (modules[y].getHighTemp() > histHighestPackTemp) histHighestPackTemp = modules[y].getHighTemp();
+      if (modules[y].getLowTemp() < histLowestPackTemp){
+        histLowestPackTemp = modules[y].getLowTemp();
+        histLowestPackTempTimeStamp = now();
+      }
+      if (modules[y].getHighTemp() > histHighestPackTemp){
+        histHighestPackTemp = modules[y].getHighTemp();
+        histHighestPackTempTimeStamp = now();
+      }
     } else {
       break;
     }
@@ -202,8 +208,14 @@ uint16_t BMSModuleManager::getAllVoltTemp() {
 
   //update high and low watermark values for voltages
   tempPackVolt = tempPackVolt / pstring;
-  if (tempPackVolt > histHighestPackVolt) histHighestPackVolt = tempPackVolt;
-  if (tempPackVolt < histLowestPackVolt) histLowestPackVolt = tempPackVolt;
+  if (tempPackVolt > histHighestPackVolt){
+    histHighestPackVolt = tempPackVolt;
+    histHighestPackVoltTimeStamp = now();
+  } 
+  if (tempPackVolt < histLowestPackVolt){
+    histLowestPackVolt = tempPackVolt;
+    histLowestPackVoltTimeStamp = now();
+  } 
 
   float tempHighCellVolt = 0.0;
   for (int y = 0; y < MAX_MODULE_ADDR; y++) {
@@ -235,10 +247,31 @@ uint16_t BMSModuleManager::getAllVoltTemp() {
 }
 
 /////////////////////////////////////////////////
+/// \brief returns the lowest temperature reached by the pack since last reset of the attributes.
+//////////////////////////////////////////////////
+float BMSModuleManager::getHistLowestPackTemp() {
+  return histHighestPackTemp;
+}
+
+/////////////////////////////////////////////////
+/// \brief returns the lowest temperature timestamp reached by the pack since last reset of the attributes.
+//////////////////////////////////////////////////
+time_t BMSModuleManager::getHistLowestPackTempTimeStamp() {
+  return histHighestPackTempTimeStamp;
+}
+
+/////////////////////////////////////////////////
 /// \brief returns the highest temperature reached by the pack since last reset of the attributes.
 //////////////////////////////////////////////////
 float BMSModuleManager::getHistHighestPackTemp() {
   return histHighestPackTemp;
+}
+
+/////////////////////////////////////////////////
+/// \brief returns the highest temperature timestamp reached by the pack since last reset of the attributes.
+//////////////////////////////////////////////////
+time_t BMSModuleManager::getHistHighestPackTempTimeStamp() {
+  return histHighestPackTempTimeStamp;
 }
 
 /////////////////////////////////////////////////
@@ -291,10 +324,24 @@ float BMSModuleManager::getHistLowestPackVolt() {
 }
 
 /////////////////////////////////////////////////
+/// \brief returns the lowest pack voltage timestamp reached since last reset of the atributes.
+//////////////////////////////////////////////////
+time_t BMSModuleManager::getHistLowestPackVoltTimeStamp() {
+  return histLowestPackVoltTimeStamp;
+}
+
+/////////////////////////////////////////////////
 /// \brief returns the highest pack voltage reached since last reset of the atributes.
 //////////////////////////////////////////////////
 float BMSModuleManager::getHistHighestPackVolt() {
   return histHighestPackVolt;
+}
+
+/////////////////////////////////////////////////
+/// \brief returns the highest pack voltage timestamp reached since last reset of the atributes.
+//////////////////////////////////////////////////
+time_t BMSModuleManager::getHistHighestPackVoltTimeStamp() {
+  return histHighestPackVoltTimeStamp;
 }
 
 /////////////////////////////////////////////////
@@ -490,8 +537,18 @@ void BMSModuleManager::printPackSummary() {
     }
   }
   LOG_CONSOLE("\n=====================================================================\n");
-  LOG_CONSOLE("\nModules: %i    Voltage: %.2fV   Avg Cell Voltage: %.2fV     Avg Temp: %.2fC\n", numFoundModules,
-              getPackVoltage(), getAvgCellVolt(), getAvgTemperature());
+  LOG_CONSOLE("\nModules: %i    Voltage: %.2fV   Avg Cell Voltage: %.2fV     Avg Temp: %.2fC\n",
+                  numFoundModules, getPackVoltage(), getAvgCellVolt(), getAvgTemperature());
+
+  LOG_CONSOLE("Lowest pack voltage %.2fV was reached at ", getHistLowestPackVolt());
+  LOG_TIMESTAMP_LN(getHistLowestPackVoltTimeStamp());
+  LOG_CONSOLE("Highest pack voltage %.2fV was reached at ", getHistHighestPackVolt());
+  LOG_TIMESTAMP_LN(getHistHighestPackVoltTimeStamp());
+  LOG_CONSOLE("Lowest pack temp %.2fV was reached at ", getHistLowestPackTemp());
+  LOG_TIMESTAMP_LN(getHistLowestPackTempTimeStamp());
+  LOG_CONSOLE("Highest pack temp %.2fV was reached at ", getHistHighestPackTemp());
+  LOG_TIMESTAMP_LN(getHistHighestPackTempTimeStamp());
+
   LOG_CONSOLE("INL_EVSE_DISC: %d\n", digitalRead(INL_EVSE_DISC));
   LOG_CONSOLE("INH_RUN: %d\n", digitalRead(INH_RUN));
   LOG_CONSOLE("INH_CHARGING: %d\n", digitalRead(INH_CHARGING));

--- a/BMSModuleManager.hpp
+++ b/BMSModuleManager.hpp
@@ -34,10 +34,15 @@ class BMSModuleManager
     float getLowCellVolt();
     float getHighCellVolt();
     float getHistLowestPackVolt();
+    time_t getHistLowestPackVoltTimeStamp();
     float getHistHighestPackVolt();
+    time_t getHistHighestPackVoltTimeStamp();
     float getHistLowestCellVolt();
     float getHistHighestCellVolt();
+    float getHistLowestPackTemp();
+    time_t getHistLowestPackTempTimeStamp();
     float getHistHighestPackTemp();
+    time_t getHistHighestPackTempTimeStamp();
     float getHistHighestCellDiffVolt();
     bool getIsFaulted();
     bool getLineFault();
@@ -54,13 +59,13 @@ class BMSModuleManager
     int pstring;
     float lowCellVolt;
     float highCellVolt;
-    float histLowestPackVolt;
-    float histHighestPackVolt;
+    float histLowestPackVolt; time_t histLowestPackVoltTimeStamp;
+    float histHighestPackVolt; time_t histHighestPackVoltTimeStamp;
     float histLowestCellVolt;
     float histHighestCellVolt;
     float histHighestCellDiffVolt;
-    float histLowestPackTemp;
-    float histHighestPackTemp;
+    float histLowestPackTemp; time_t histLowestPackTempTimeStamp;
+    float histHighestPackTemp; time_t histHighestPackTempTimeStamp;
     float highTemp;
     float lowTemp;
     BMSModule modules[MAX_MODULE_ADDR + 1]; // store data for as many modules as we've configured for.

--- a/Config.cpp
+++ b/Config.cpp
@@ -11,7 +11,7 @@ Settings::Settings()
     under_v_setpoint("under_v_setpoint", true, 0.0f, 3.0f, 2.5f, 3.5f, "Triggers Under V error"),
     max_charge_v_setpoint("max_charge_v_setpoint", true, 0.0f, 4.2f, 3.8f, 4.25f, "Stops charging"),
     charger_cycle_v_setpoint("charger_cycle_v_setpoint", true, 0.0f, 4.17f, 2.5f, 4.25f, "Voltage treshold to force a charging cycle"),
-    trickle_charge_v_setpoint("trickle_charge_v_setpoint", true, 0.0f, 4.19f, 2.5f, 4.25f, "Transition to trickle charging when highest cell reaches this value"),
+    top_balance_v_setpoint("top_balance_v_setpoint", true, 0.0f, 4.19f, 2.5f, 4.25f, "Transition to top balancing when highest cell reaches this value"),
     warn_cell_v_offset("warn_cell_v_offset", true, 0.0f, 0.1f, 0.00f, 3.0f, "TODO, issue a warning on OLED and serial console if a cell is that close to a OV or UV fault"),
     floor_duty_coolant_pump("floor_duty_coolant_pump", true, 0.0f, 0.25f, 0.00f, 1.0f, "Lowest pump duty cucle when in RUN or CHARGING"),
     cooling_lowt_setpoint("cooling_lowt_setpoint", true, 0.0f, 25.0f, -20.0f, 65.0f, "Threshold at which coolant pump gradually increases duty up to max"),
@@ -43,7 +43,7 @@ Settings::Settings()
   parameters.push_back(&under_v_setpoint);
   parameters.push_back(&max_charge_v_setpoint);
   parameters.push_back(&charger_cycle_v_setpoint);
-  parameters.push_back(&trickle_charge_v_setpoint);
+  parameters.push_back(&top_balance_v_setpoint);
   parameters.push_back(&warn_cell_v_offset);
   parameters.push_back(&floor_duty_coolant_pump);
   parameters.push_back(&cooling_lowt_setpoint);

--- a/Config.hpp
+++ b/Config.hpp
@@ -140,7 +140,7 @@ public:
   ParamImpl<float> under_v_setpoint;
   ParamImpl<float> max_charge_v_setpoint;
   ParamImpl<float> charger_cycle_v_setpoint;
-  ParamImpl<float> trickle_charge_v_setpoint;
+  ParamImpl<float> top_balance_v_setpoint;
   ParamImpl<float> warn_cell_v_offset;
   ParamImpl<float> floor_duty_coolant_pump;
   ParamImpl<float> cooling_lowt_setpoint;

--- a/Controller.hpp
+++ b/Controller.hpp
@@ -128,7 +128,7 @@ public:
     STANDBY,
     PRE_CHARGE,
     CHARGING,
-    TRICKLE_CHARGING,
+    TOP_BALANCING,
     POST_CHARGE,
     RUN
   };
@@ -175,6 +175,7 @@ private:
   uint32_t period;
   ControllerState state;
   bool canOn = false;
+  time_t lastResetTimeStamp;
 
   //run-time functions
   void syncModuleDataObjects();  //gathers all the data from the boards and populates the BMSModel object instances
@@ -187,7 +188,7 @@ private:
   void standby();
   void pre_charge();
   void charging();
-  void trickle_charging();
+  void top_balancing();
   void post_charge();
   void run();
 

--- a/Logger.cpp
+++ b/Logger.cpp
@@ -1,3 +1,4 @@
+#include "TimeLib.h"
 /*
    Logger.cpp
 
@@ -155,7 +156,8 @@ bool Logger::isDebug() {
 void Logger::printTimeStamp(time_t t) {
   tmElements_t tm;
   breakTime(t, tm);
-  console("%04d-%02d-%02dT%02d:%02d:%02d", tm.Year + 1970, tm.Month, tm.Day, tm.Hour, tm.Minute, tm.Second);
+  //console("%04d-%02d-%02dT%02d:%02d:%02d", tm.Year + 1970, tm.Month, tm.Day, tm.Hour, tm.Minute, tm.Second);
+  console("%s %02d, %02d %02d:%02d:%02d", monthShortStr(tm.Month), tm.Day, tm.Year + 1970, tm.Hour, tm.Minute, tm.Second);
 }
 
 /////////////////////////////////////////////////

--- a/Oled.cpp
+++ b/Oled.cpp
@@ -136,8 +136,8 @@ void Oled::printFormat5() {
     case Controller::CHARGING:
       Oled::printCentre("CHARGING", 1);
       break;
-    case Controller::TRICKLE_CHARGING:
-      Oled::printCentre("TRICKLE_CHARGING", 1);
+    case Controller::TOP_BALANCING:
+      Oled::printCentre("TOP_BALANCING", 1);
       break;
     case Controller::POST_CHARGE:
       Oled::printCentre("PRE_CHARGE", 1);


### PR DESCRIPTION
4 new features:
- Afficher l’heure du last reset plutôt que le temps depuis, maintenant qu’on a un RTC 😉 
- Afficher un format simplifié (moins techno) de date and time genre « Aug 8, 2023 16:41:00 » 
- Afficher le pack voltage (total) le plus bas (min) et le plus haut (max) détecté, ainsi que les températures minimales et maximale détectées, avec la commande « 1 », idéalement avec le time stamp 😉 
- Changer le terme « trickle charge » pour « top balancing » ou « fine balancing » pour le distinguer du « rough balancing »
- some can rework